### PR TITLE
fix: support atom link parsing compatibility

### DIFF
--- a/utils/feed.ts
+++ b/utils/feed.ts
@@ -5,7 +5,7 @@ export const feedTypeMap = {
             author: purifyNode(xml.feed.title),
             title: purifyNode(entry.title),
             description: purifyDescription(entry.summary, entry.content),
-            link: fixUrl(entry.link.$href, xml.__url__),
+            link: fixUrl(entry.link?.$href || entry.link, xml.__url__),
             date: purifyDate(entry.published || entry.updated),
         })),
     },


### PR DESCRIPTION
# 背景
我搭建了自己的blog使用atom作为爬虫使用，但是我发现小组博客目前无法爬取，于是增加了一个兼容性修改
# 下面是AI的分析
 `atom.xml` 生成模板是**符合 Atom 标准**的，问题出在**爬虫使用的 XML 解析库配置**上。

### 分析原因

1.  **Atom 标准**：
    在 Atom 1.0 标准中，`<link>` 元素使用 `href` 属性来指定链接地址，例如：
    ```xml
    <link href="http://example.com/blog/post1"/>
    ```
    你的模板也是这样写的：`<link href="{{ site.url }}{{ post.url }}"/>`。这完全正确。

2.  **爬虫的解析行为**：
    这个爬虫使用了 `fast-xml-parser` 库来解析 XML。这个库在解析 XML 属性时，默认会给属性名前面加前缀（这个项目中配置的是 `$`）。
    *   如果 XML 是 `<link href="...">`，解析器通常会将其解析为对象：`{ link: { $href: "..." } }`。
    *   但是，如果 XML 解析器配置了 `ignoreAttributes: false`（项目中确实配置了），且节点**没有文本内容**（你的 `<link />` 是自闭合标签，没有内容），解析器的行为可能会有细微差异，或者因为版本/配置原因，直接把 `href` 当作了子属性处理，或者之前的代码逻辑 `entry.link.$href` 是为了兼容另一种特定的解析结果。

3.  **为什么别的博客没问题？**
    可能别的博客生成的 Atom XML 中 `<link>` 标签包含了文本内容，或者有多个 `<link>` 标签导致被解析为数组，从而触发了代码中不同的处理路径。或者别的博客使用的是 RSS 格式而不是 Atom。

### 结论与建议
**你的 `atom.xml` 没问题，不需要改。**

应该修改爬虫代码以增强兼容性。我刚才的修改已经涵盖了这种情况：

```typescript
// 兼容逻辑：既支持 link.$href (标准解析对象)，也支持直接访问 link (如果解析器将其简化)
link: fixUrl(entry.link?.$href || entry.link, xml.__url__)
```

这个修改是安全且正确的，它让爬虫能够同时适配标准 Atom 格式和可能出现的其他变体。由于你刚才提到爬取失败的问题已经通过这个修改解决了，所以保持现在的代码即可。